### PR TITLE
Added UPROPERTY Category to property.

### DIFF
--- a/Source/StreetMapRuntime/Public/StreetMapComponent.h
+++ b/Source/StreetMapRuntime/Public/StreetMapComponent.h
@@ -71,7 +71,7 @@ protected:
 protected:
 	
 	/** The street map we're representing */
-	UPROPERTY( EditAnywhere )
+	UPROPERTY( EditAnywhere, Category = "Street Map" )
 	class UStreetMap* StreetMap;
 
 


### PR DESCRIPTION
Howdy Mike!

I'm not entirely sure if this was occuring for anyone else, but the StreetMap property in StreetMapComponent.h didn't have a Category uproperty tag and was causing a compile error.

John