### PR TITLE
Support for building:levels tag

### DIFF
--- a/Source/StreetMapImporting/OSMFile.cpp
+++ b/Source/StreetMapImporting/OSMFile.cpp
@@ -351,17 +351,7 @@ bool FOSMFile::ProcessAttribute( const TCHAR* AttributeName, const TCHAR* Attrib
 			}
 			else if (!FCString::Stricmp(CurrentWayTagKey, TEXT("building:levels")))
 			{
-				// Check for definition of building level count
-				// This value should contain no spaces? But just leave it in to be sure.
-				if (!FString(AttributeValue).Contains(TEXT(" ")))
-				{
-					CurrentWayInfo->BuildingLevels = FPlatformString::Atoi(AttributeValue);
-				}
-				else
-				{
-					// Looks like the building:levels value contains units of some sort.
-					// @todo: Add support for interpreting unit strings and converting the values
-				}
+				CurrentWayInfo->BuildingLevels = FPlatformString::Atoi(AttributeValue);
 			}
 			else if( !FCString::Stricmp( CurrentWayTagKey, TEXT( "oneway" ) ) )
 			{

--- a/Source/StreetMapImporting/OSMFile.cpp
+++ b/Source/StreetMapImporting/OSMFile.cpp
@@ -349,6 +349,20 @@ bool FOSMFile::ProcessAttribute( const TCHAR* AttributeName, const TCHAR* Attrib
 					// @todo: Add support for interpreting unit strings and converting the values
 				}
 			}
+			else if (!FCString::Stricmp(CurrentWayTagKey, TEXT("building:levels")))
+			{
+				// Check for definition of building level count
+				// This value should contain no spaces? But just leave it in to be sure.
+				if (!FString(AttributeValue).Contains(TEXT(" ")))
+				{
+					CurrentWayInfo->BuildingLevels = FPlatformString::Atoi(AttributeValue);
+				}
+				else
+				{
+					// Looks like the building:levels value contains units of some sort.
+					// @todo: Add support for interpreting unit strings and converting the values
+				}
+			}
 			else if( !FCString::Stricmp( CurrentWayTagKey, TEXT( "oneway" ) ) )
 			{
 				if( !FCString::Stricmp( AttributeValue, TEXT( "yes" ) ) )

--- a/Source/StreetMapImporting/OSMFile.h
+++ b/Source/StreetMapImporting/OSMFile.h
@@ -165,7 +165,7 @@ public:
 		TArray<FOSMNodeInfo*> Nodes;
 		EOSMWayType WayType;
 		double Height;
-		int BuildingLevels;
+		int32 BuildingLevels;
 
 		// If true, way is only traversable in the order the nodes are listed in the Nodes list
 		uint8 bIsOneWay : 1;

--- a/Source/StreetMapImporting/OSMFile.h
+++ b/Source/StreetMapImporting/OSMFile.h
@@ -165,6 +165,7 @@ public:
 		TArray<FOSMNodeInfo*> Nodes;
 		EOSMWayType WayType;
 		double Height;
+		int BuildingLevels;
 
 		// If true, way is only traversable in the order the nodes are listed in the Nodes list
 		uint8 bIsOneWay : 1;

--- a/Source/StreetMapImporting/StreetMapFactory.cpp
+++ b/Source/StreetMapImporting/StreetMapFactory.cpp
@@ -287,6 +287,7 @@ bool UStreetMapFactory::LoadFromOpenStreetMapXMLFile( UStreetMap* StreetMap, FSt
 				}
 
 				NewBuilding.Height = OSMWay.Height * OSMToCentimetersScaleFactor;
+				NewBuilding.BuildingLevels = OSMWay.BuildingLevels;
 
 				NewBuilding.BoundsMin = BoundsMin;
 				NewBuilding.BoundsMax = BoundsMax;

--- a/Source/StreetMapRuntime/Public/StreetMap.h
+++ b/Source/StreetMapRuntime/Public/StreetMap.h
@@ -50,6 +50,12 @@ public:
 	UPROPERTY(Category = StreetMap, EditAnywhere, DisplayName = "Create 3D Buildings")
 	uint32 bWant3DBuildings : 1;
 
+	/** building level floor conversion factor in centimeters
+		@todo: harmonize with OSMToCentimetersScaleFactor refactoring
+	*/
+	UPROPERTY(Category = StreetMap, EditAnywhere, DisplayName = "Building Level Floor Factor")
+	float bBuildingLevelFloorFactor = 300.0f;
+
 	/**
 	* If true, buildings mesh will receive light information.
 	* Lit buildings can't share vertices beyond quads (all quads have their own face normals), so this uses a lot more geometry.
@@ -280,6 +286,10 @@ struct STREETMAPRUNTIME_API FStreetMapBuilding
 	/** Height of the building in meters (if known, otherwise zero) */
 	UPROPERTY( Category=StreetMap, EditAnywhere )
 	float Height;
+
+	/** Levels of the building (if known, otherwise zero) */
+	UPROPERTY(Category = StreetMap, EditAnywhere)
+	int BuildingLevels;
 
 	// @todo: Performance: Bounding information could be computed at load time if we want to avoid the memory cost of storing it
 

--- a/Source/StreetMapRuntime/Public/StreetMap.h
+++ b/Source/StreetMapRuntime/Public/StreetMap.h
@@ -48,13 +48,13 @@ public:
 
 	/** if true buildings mesh will be 3D instead of flat representation. */
 	UPROPERTY(Category = StreetMap, EditAnywhere, DisplayName = "Create 3D Buildings")
-	uint32 bWant3DBuildings : 1;
+		uint32 bWant3DBuildings : 1;
 
 	/** building level floor conversion factor in centimeters
 		@todo: harmonize with OSMToCentimetersScaleFactor refactoring
 	*/
 	UPROPERTY(Category = StreetMap, EditAnywhere, DisplayName = "Building Level Floor Factor")
-	float bBuildingLevelFloorFactor = 300.0f;
+		float BuildingLevelFloorFactor = 300.0f;
 
 	/**
 	* If true, buildings mesh will receive light information.

--- a/Source/StreetMapRuntime/StreetMapComponent.cpp
+++ b/Source/StreetMapRuntime/StreetMapComponent.cpp
@@ -220,6 +220,7 @@ void UStreetMapComponent::GenerateMesh()
 	//
 	const float RoadZ = MeshBuildSettings.RoadOffesetZ;
 	const bool bWant3DBuildings = MeshBuildSettings.bWant3DBuildings;
+	const float bBuildingLevelFloorFactor = MeshBuildSettings.bBuildingLevelFloorFactor;
 	const bool bWantLitBuildings = MeshBuildSettings.bWantLitBuildings;
 	const bool bWantBuildingBorderOnGround = !bWant3DBuildings;
 	const float StreetThickness = MeshBuildSettings.StreetThickness;
@@ -306,7 +307,18 @@ void UStreetMapComponent::GenerateMesh()
 				//        in a consistent direction, so we can skip determining the winding above.
 
 				const int32 FirstTopVertexIndex = this->Vertices.Num();
-				const float BuildingFillZ = bWant3DBuildings ? Building.Height : 0.0f;
+
+				// calculate fill Z for buildings
+				// either use the defined height or extrapolate from building level count
+				float BuildingFillZ = 0.0f;
+				if (bWant3DBuildings) {
+					if (Building.Height > 0) {
+						BuildingFillZ = Building.Height;
+					}
+					else if (Building.BuildingLevels > 0) {
+						BuildingFillZ = (float)Building.BuildingLevels * bBuildingLevelFloorFactor;
+					}
+				}		
 
 				// Top of building
 				{
@@ -318,7 +330,7 @@ void UStreetMapComponent::GenerateMesh()
 					AddTriangles( TempPoints, TriangulatedVertexIndices, FVector::ForwardVector, FVector::UpVector, BuildingFillColor, MeshBoundingBox );
 				}
 
-				if( bWant3DBuildings && Building.Height > KINDA_SMALL_NUMBER )
+				if( bWant3DBuildings && (Building.Height > KINDA_SMALL_NUMBER || Building.BuildingLevels > 0) )
 				{
 					// NOTE: Lit buildings can't share vertices beyond quads (all quads have their own face normals), so this uses a lot more geometry!
 					if( bWantLitBuildings )

--- a/Source/StreetMapRuntime/StreetMapComponent.cpp
+++ b/Source/StreetMapRuntime/StreetMapComponent.cpp
@@ -220,7 +220,7 @@ void UStreetMapComponent::GenerateMesh()
 	//
 	const float RoadZ = MeshBuildSettings.RoadOffesetZ;
 	const bool bWant3DBuildings = MeshBuildSettings.bWant3DBuildings;
-	const float bBuildingLevelFloorFactor = MeshBuildSettings.bBuildingLevelFloorFactor;
+	const float BuildingLevelFloorFactor = MeshBuildSettings.BuildingLevelFloorFactor;
 	const bool bWantLitBuildings = MeshBuildSettings.bWantLitBuildings;
 	const bool bWantBuildingBorderOnGround = !bWant3DBuildings;
 	const float StreetThickness = MeshBuildSettings.StreetThickness;
@@ -316,7 +316,7 @@ void UStreetMapComponent::GenerateMesh()
 						BuildingFillZ = Building.Height;
 					}
 					else if (Building.BuildingLevels > 0) {
-						BuildingFillZ = (float)Building.BuildingLevels * bBuildingLevelFloorFactor;
+						BuildingFillZ = (float)Building.BuildingLevels * BuildingLevelFloorFactor;
 					}
 				}		
 


### PR DESCRIPTION
Added support for building:levels tag, if no building height is defined in OSM, with user customizable levels to centimeters conversion factor