### PR TITLE
Fix deprecated Nav ref for 4.20

### DIFF
--- a/Source/StreetMapRuntime/StreetMapComponent.cpp
+++ b/Source/StreetMapRuntime/StreetMapComponent.cpp
@@ -516,7 +516,7 @@ void UStreetMapComponent::UpdateNavigationIfNeeded()
 {
 	if (bCanEverAffectNavigation || bNavigationRelevant)
 	{
-		UNavigationSystem::UpdateComponentInNavOctree(*this);
+		FNavigationSystem::UpdateComponentData(*this);
 	}
 }
 


### PR DESCRIPTION
Switched to FNavigationSystem to allow for recompile. Now works with 4.20-release