### PR TITLE
fix for compiling on 4.22+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Street Map Plugin for UE4
+# Street Map Plugin for UE4 [4.22]
 
 This plugin allows you to import **OpenStreetMap** XML data into your **Unreal Engine 4** project as a new StreetMap asset type.  You can use the example **Street Map Component** to render streets and buildings.
 

--- a/Source/StreetMapImporting/StreetMapActorFactory.h
+++ b/Source/StreetMapImporting/StreetMapActorFactory.h
@@ -1,7 +1,7 @@
 // Copyright 2017 Mike Fricker. All Rights Reserved.
 
 #pragma once
-
+#include "ActorFactories/ActorFactory.h"
 #include "StreetMapActorFactory.generated.h"
 
 UCLASS()

--- a/Source/StreetMapImporting/StreetMapImporting.Build.cs
+++ b/Source/StreetMapImporting/StreetMapImporting.Build.cs
@@ -7,6 +7,7 @@ namespace UnrealBuildTool.Rules
         public StreetMapImporting(ReadOnlyTargetRules Target)
 			: base(Target)
         {
+			PrivatePCHHeaderFile = "StreetMapImporting.h";
             PrivateDependencyModuleNames.AddRange(
                 new string[] {
                     "Core",
@@ -21,7 +22,6 @@ namespace UnrealBuildTool.Rules
                     "SlateCore",
                     "PropertyEditor",
                     "RenderCore",
-                    "ShaderCore",
                     "RHI",
                     "RawMesh",
                     "AssetTools",

--- a/Source/StreetMapRuntime/StreetMapComponent.cpp
+++ b/Source/StreetMapRuntime/StreetMapComponent.cpp
@@ -516,7 +516,7 @@ void UStreetMapComponent::UpdateNavigationIfNeeded()
 {
 	if (bCanEverAffectNavigation || bNavigationRelevant)
 	{
-		UNavigationSystem::UpdateComponentInNavOctree(*this);
+		FNavigationSystem::UpdateComponentData(*this);
 	}
 }
 

--- a/Source/StreetMapRuntime/StreetMapRuntime.Build.cs
+++ b/Source/StreetMapRuntime/StreetMapRuntime.Build.cs
@@ -7,6 +7,7 @@ namespace UnrealBuildTool.Rules
         public StreetMapRuntime(ReadOnlyTargetRules Target)
 			: base(Target)
 		{
+			PrivatePCHHeaderFile = "StreetMapRuntime.h";
 			PrivateDependencyModuleNames.AddRange(
 				new string[] {
                     "Core",
@@ -14,7 +15,6 @@ namespace UnrealBuildTool.Rules
 					"Engine",
 					"RHI",
 					"RenderCore",
-					"ShaderCore",
                     "PropertyEditor"
                 }
 			);

--- a/Source/StreetMapRuntime/StreetMapSceneProxy.cpp
+++ b/Source/StreetMapRuntime/StreetMapSceneProxy.cpp
@@ -4,13 +4,15 @@
 #include "StreetMapSceneProxy.h"
 #include "StreetMapComponent.h"
 #include "Runtime/Engine/Public/SceneManagement.h"
+#include "Runtime/Renderer/Public/MeshPassProcessor.h"
+#include "Runtime/Renderer/Public/PrimitiveSceneInfo.h"
 
 
 FStreetMapSceneProxy::FStreetMapSceneProxy(const UStreetMapComponent* InComponent)
 	: FPrimitiveSceneProxy(InComponent),
+	VertexFactory(GetScene().GetFeatureLevel(), "FStreetMapSceneProxy"),
 	StreetMapComp(InComponent),
-	CollisionResponse(InComponent->GetCollisionResponseToChannels()),
-	VertexFactory(GetScene().GetFeatureLevel(), "FStreetMapSceneProxy")
+	CollisionResponse(InComponent->GetCollisionResponseToChannels())
 {
 
 }
@@ -22,7 +24,6 @@ void FStreetMapSceneProxy::Init(const UStreetMapComponent* InComponent, const TA
 
 	MaterialInterface = nullptr;
 	this->MaterialRelevance = InComponent->GetMaterialRelevance(GetScene().GetFeatureLevel());
-
 
 	// Copy vertex data
 	const int32 NumVerts = Vertices.Num();
@@ -86,7 +87,6 @@ void FStreetMapSceneProxy::InitResources()
 	BeginInitResource(&VertexFactory);
 }
 
-
 bool FStreetMapSceneProxy::MustDrawMeshDynamically( const FSceneView& View ) const
 {
 	return ( AllowDebugViewmodes() && View.Family->EngineShowFlags.Wireframe ) || IsSelected();
@@ -121,7 +121,7 @@ bool FStreetMapSceneProxy::CanBeOccluded() const
 }
 
 
-void FStreetMapSceneProxy::MakeMeshBatch( FMeshBatch& Mesh, FMaterialRenderProxy* WireframeMaterialRenderProxyOrNull, bool bDrawCollision) const
+void FStreetMapSceneProxy::MakeMeshBatch( FMeshBatch& Mesh, class FMeshElementCollector& Collector, FMaterialRenderProxy* WireframeMaterialRenderProxyOrNull, bool bDrawCollision) const
 {
 	FMaterialRenderProxy* MaterialProxy = NULL;
 	if( WireframeMaterialRenderProxyOrNull != nullptr )
@@ -132,21 +132,28 @@ void FStreetMapSceneProxy::MakeMeshBatch( FMeshBatch& Mesh, FMaterialRenderProxy
 	{
 		if (bDrawCollision)
 		{
-			MaterialProxy = new FColoredMaterialRenderProxy(GEngine->ShadedLevelColorationUnlitMaterial->GetRenderProxy(IsSelected(), IsHovered()), FColor::Cyan);
+			MaterialProxy = new FColoredMaterialRenderProxy(GEngine->ShadedLevelColorationUnlitMaterial->GetRenderProxy(), FLinearColor::Blue);
 		}
 		else if (MaterialProxy == nullptr)
 		{
-			MaterialProxy = StreetMapComp->GetDefaultMaterial()->GetRenderProxy(IsSelected());
+			MaterialProxy = StreetMapComp->GetDefaultMaterial()->GetRenderProxy();
 		}
 	}
 	
 	FMeshBatchElement& BatchElement = Mesh.Elements[0];
+
 	BatchElement.IndexBuffer = &IndexBuffer32;
 	Mesh.bWireframe = WireframeMaterialRenderProxyOrNull != nullptr;
 	Mesh.VertexFactory = &VertexFactory;
 	Mesh.MaterialRenderProxy = MaterialProxy;
 	Mesh.CastShadow = true;
-	BatchElement.PrimitiveUniformBuffer = CreatePrimitiveUniformBufferImmediate(GetLocalToWorld(), GetBounds(), GetLocalBounds(), true, UseEditorDepthTest());
+	//	BatchElement.PrimitiveUniformBufferResource = &GetUniformBuffer();
+	//	BatchElement.PrimitiveUniformBuffer = CreatePrimitiveUniformBufferImmediate(GetLocalToWorld(), GetBounds(), GetLocalBounds(), true, UseEditorDepthTest());
+
+	FDynamicPrimitiveUniformBuffer& DynamicPrimitiveUniformBuffer = Collector.AllocateOneFrameResource<FDynamicPrimitiveUniformBuffer>();
+	DynamicPrimitiveUniformBuffer.Set(GetLocalToWorld(), GetLocalToWorld(), GetBounds(), GetLocalBounds(), true, false, UseEditorDepthTest());
+	BatchElement.PrimitiveUniformBufferResource = &DynamicPrimitiveUniformBuffer.UniformBuffer;	
+
 	BatchElement.FirstIndex = 0;
 	const int IndexCount = IndexBuffer32.Indices.Num();
 	BatchElement.NumPrimitives = IndexCount / 3;
@@ -155,22 +162,24 @@ void FStreetMapSceneProxy::MakeMeshBatch( FMeshBatch& Mesh, FMaterialRenderProxy
 	Mesh.ReverseCulling = IsLocalToWorldDeterminantNegative();
 	Mesh.Type = PT_TriangleList;
 	Mesh.DepthPriorityGroup = SDPG_World;
+
+	
 }
 
-
+/*
 void FStreetMapSceneProxy::DrawStaticElements( FStaticPrimitiveDrawInterface* PDI )
 {
 	const int IndexCount = IndexBuffer32.Indices.Num();
 	if( VertexBuffer.PositionVertexBuffer.GetNumVertices() > 0 && IndexCount > 0 )
 	{
 		const float ScreenSize = 1.0f;
-
 		FMeshBatch MeshBatch;
 		MakeMeshBatch( MeshBatch, nullptr);
 		PDI->DrawMesh( MeshBatch, ScreenSize );
+		
 	}
 }
-
+*/
 
 void FStreetMapSceneProxy::GetDynamicMeshElements(const TArray<const FSceneView*>& Views, const FSceneViewFamily& ViewFamily, uint32 VisibilityMap, class FMeshElementCollector& Collector) const
 {
@@ -183,7 +192,7 @@ void FStreetMapSceneProxy::GetDynamicMeshElements(const TArray<const FSceneView*
 
 			const bool bIsWireframe = AllowDebugViewmodes() && View.Family->EngineShowFlags.Wireframe;
 
-			FColoredMaterialRenderProxy* WireframeMaterialRenderProxy = GEngine->WireframeMaterial && bIsWireframe ? new FColoredMaterialRenderProxy(GEngine->WireframeMaterial->GetRenderProxy(IsSelected()), FLinearColor(0, 0.5f, 1.f)) : NULL;
+			FColoredMaterialRenderProxy* WireframeMaterialRenderProxy = GEngine->WireframeMaterial && bIsWireframe ? new FColoredMaterialRenderProxy(GEngine->WireframeMaterial->GetRenderProxy(), FLinearColor(0, 0.5f, 1.f)) : NULL;
 
 
 			if (MustDrawMeshDynamically(View))
@@ -197,8 +206,8 @@ void FStreetMapSceneProxy::GetDynamicMeshElements(const TArray<const FSceneView*
 				}
 
 				// Draw the mesh!
-				FMeshBatch& MeshBatch = Collector.AllocateMesh();
-				MakeMeshBatch(MeshBatch, WireframeMaterialRenderProxy, bCanDrawCollision);
+				FMeshBatch& MeshBatch = Collector.AllocateMesh(); 
+				MakeMeshBatch(MeshBatch, Collector, WireframeMaterialRenderProxy, bCanDrawCollision);
 				Collector.AddMesh(ViewIndex, MeshBatch);
 			}
 		}

--- a/Source/StreetMapRuntime/StreetMapSceneProxy.h
+++ b/Source/StreetMapRuntime/StreetMapSceneProxy.h
@@ -82,7 +82,7 @@ protected:
 	void InitResources();
 
 	/** Makes a MeshBatch for rendering.  Called every time the mesh is drawn */
-	void MakeMeshBatch(struct FMeshBatch& Mesh, class FMaterialRenderProxy* WireframeMaterialRenderProxyOrNull, bool bDrawCollision = false) const;
+	void MakeMeshBatch(struct FMeshBatch& Mesh, class FMeshElementCollector& Collector, class FMaterialRenderProxy* WireframeMaterialRenderProxyOrNull, bool bDrawCollision = false) const;
 
 	/** Checks to see if this mesh must be drawn during the dynamic pass.  Note that even when this returns false, we may still
 	have other (debug) geometry to render as dynamic */
@@ -92,7 +92,7 @@ protected:
 	bool IsInCollisionView(const FEngineShowFlags& EngineShowFlags) const;
 
 	// FPrimitiveSceneProxy interface
-	virtual void DrawStaticElements(class FStaticPrimitiveDrawInterface* PDI) override;
+	//virtual void DrawStaticElements(class FStaticPrimitiveDrawInterface* PDI) override;
 	virtual void GetDynamicMeshElements(const TArray<const FSceneView*>& Views, const FSceneViewFamily& ViewFamily, uint32 VisibilityMap, class FMeshElementCollector& Collector) const override;
 	virtual uint32 GetMemoryFootprint(void) const override;
 	virtual FPrimitiveViewRelevance GetViewRelevance(const class FSceneView* View) const override;


### PR DESCRIPTION
primarily replaces old uniform buffer to dynamic one, which should be used to draw meshes after render pipeline refactoring in 4.22.