### PR TITLE
In UE 4.22 module ShaderCore is merged into RenderCore

### DIFF
--- a/Source/StreetMapImporting/StreetMapImporting.Build.cs
+++ b/Source/StreetMapImporting/StreetMapImporting.Build.cs
@@ -21,7 +21,6 @@ namespace UnrealBuildTool.Rules
                     "SlateCore",
                     "PropertyEditor",
                     "RenderCore",
-                    "ShaderCore",
                     "RHI",
                     "RawMesh",
                     "AssetTools",

--- a/Source/StreetMapRuntime/StreetMapRuntime.Build.cs
+++ b/Source/StreetMapRuntime/StreetMapRuntime.Build.cs
@@ -14,7 +14,6 @@ namespace UnrealBuildTool.Rules
 					"Engine",
 					"RHI",
 					"RenderCore",
-					"ShaderCore",
                     "PropertyEditor"
                 }
 			);


### PR DESCRIPTION
so it need to be removed from the dependencies list